### PR TITLE
fix: Fix theme 

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/equalizer/EqualizerFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/equalizer/EqualizerFragment.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.PorterDuff;
 import android.media.audiofx.AudioEffect;
 import android.os.Build;
 import android.os.Bundle;
@@ -197,6 +198,8 @@ public class EqualizerFragment extends BaseFragment implements
         toolbar.inflateMenu(R.menu.menu_equalizer);
         toolbar.setNavigationOnClickListener(v -> getNavigationController().popViewController());
         toolbar.setOnMenuItemClickListener(this);
+        toolbar.getNavigationIcon().setColorFilter(getResources().getColor(R.color.white), PorterDuff.Mode.SRC_ATOP);
+
 
         MenuItem item = toolbar.getMenu().findItem(R.id.action_equalizer);
         SwitchCompat switchItem = (SwitchCompat) item.getActionView();

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/main/LibraryController.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/main/LibraryController.java
@@ -2,6 +2,8 @@ package com.simplecity.amp_library.ui.screens.main;
 
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
@@ -22,6 +24,8 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
@@ -187,6 +191,13 @@ public class LibraryController extends BaseFragment implements
         super.onCreateOptionsMenu(menu, inflater);
 
         inflater.inflate(R.menu.menu_library, menu);
+        for(int i = 0; i < menu.size(); i++){
+            Drawable drawable = menu.getItem(i).getIcon();
+            if(drawable != null) {
+                drawable.mutate();
+                drawable.setColorFilter(getResources().getColor(R.color.white), PorterDuff.Mode.SRC_ATOP);
+            }
+        }
 
         if (CastManager.isCastAvailable(getContext(), settingsManager)) {
             MenuItem menuItem = CastButtonFactory.setUpMediaRouteButton(getContext(), menu, R.id.media_route_menu_item);
@@ -234,7 +245,6 @@ public class LibraryController extends BaseFragment implements
         pager.setAdapter(pagerAdapter);
         pager.setOffscreenPageLimit(pagerAdapter.getCount() - 1);
         pager.setCurrentItem(currentPage);
-
         slidingTabLayout.setupWithViewPager(pager);
 
         pager.postDelayed(() -> {

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/main/LibraryController.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/main/LibraryController.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -29,6 +30,8 @@ import android.widget.TextView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.Unbinder;
+
+import com.afollestad.aesthetic.ActiveInactiveColors;
 import com.afollestad.aesthetic.Aesthetic;
 import com.afollestad.aesthetic.ViewBackgroundAction;
 import com.annimon.stream.Stream;
@@ -64,6 +67,7 @@ import com.simplecity.amp_library.utils.SettingsManager;
 import com.simplecity.amp_library.utils.ShuttleUtils;
 import com.simplecity.multisheetview.ui.view.MultiSheetView;
 import dagger.android.support.AndroidSupportInjection;
+import io.reactivex.Observable;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import java.util.ArrayList;
@@ -74,6 +78,7 @@ import test.com.androidnavigation.fragment.FragmentInfo;
 
 import static com.afollestad.aesthetic.Rx.distinctToMainThread;
 import static com.afollestad.aesthetic.Rx.onErrorLogAndRethrow;
+import static com.afollestad.aesthetic.Util.adjustAlpha;
 
 public class LibraryController extends BaseFragment implements
         AlbumArtistListFragment.AlbumArtistClickListener,
@@ -149,6 +154,10 @@ public class LibraryController extends BaseFragment implements
         ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
 
         setupViewPager();
+        Handler handler = new Handler();
+        handler.postDelayed(() -> slidingTabLayout.setTabTextColors(
+                getResources().getColor(R.color.colorAccent),
+                getResources().getColor(R.color.colorAccent)), 600);
 
         return rootView;
     }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
@@ -88,14 +88,9 @@ public class MainActivity extends BaseActivity implements
 
         setContentView(R.layout.activity_main);
 
-        if(Aesthetic.isFirstTime(this))
-            Aesthetic.get(this)
-                    .activityTheme(R.style.AppTheme_Light)
-                    .isDark(false)
-                    .colorPrimaryRes(R.color.colorPrimary)
-                    .colorAccentRes(R.color.colorAccent)
-                    .colorStatusBarAuto()
-                    .apply();
+        // If we haven't set any defaults, do that now
+
+
 
         Permiso.getInstance().setActivity(this);
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.IBinder;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
@@ -291,6 +292,8 @@ public class MainActivity extends BaseActivity implements
                 super.onDrawerSlide(drawerView, 0);
             }
         };
+        new Handler().postDelayed(() ->toggle.getDrawerArrowDrawable()
+                        .setColor(getResources().getColor(R.color.colorAccent)), 600);
         drawer.addDrawerListener(toggle);
         toggle.syncState();
     }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
@@ -88,6 +88,15 @@ public class MainActivity extends BaseActivity implements
 
         setContentView(R.layout.activity_main);
 
+        if(Aesthetic.isFirstTime(this))
+            Aesthetic.get(this)
+                    .activityTheme(R.style.AppTheme_Light)
+                    .isDark(false)
+                    .colorPrimaryRes(R.color.colorPrimary)
+                    .colorAccentRes(R.color.colorAccent)
+                    .colorStatusBarAuto()
+                    .apply();
+
         Permiso.getInstance().setActivity(this);
 
         navigationView = findViewById(R.id.navView);

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
@@ -88,9 +88,15 @@ public class MainActivity extends BaseActivity implements
 
         setContentView(R.layout.activity_main);
 
-        // If we haven't set any defaults, do that now
-
-
+        if(Aesthetic.isFirstTime(this)) {
+            Aesthetic.get(this)
+                    .activityTheme(R.style.AppTheme_Light)
+                    .isDark(false)
+                    .colorPrimaryRes(R.color.colorPrimary)
+                    .colorAccentRes(R.color.colorAccent)
+                    .colorStatusBarAuto()
+                    .apply();
+        }
 
         Permiso.getInstance().setActivity(this);
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsParentFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsParentFragment.java
@@ -2,6 +2,7 @@ package com.simplecity.amp_library.ui.settings;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -98,6 +99,7 @@ public class SettingsParentFragment extends BaseNavigationController implements
 
         toolbar.setTitle(titleResId);
         toolbar.setNavigationOnClickListener(v -> getActivity().onBackPressed());
+        toolbar.getNavigationIcon().setColorFilter(getResources().getColor(R.color.white), PorterDuff.Mode.SRC_ATOP);
 
         return rootView;
     }

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -53,7 +53,7 @@
                     android:transitionName="toolbar"
                     app:layout_collapseMode="none"
                     android:tag=":aesthetic_ignore"
-
+                    app:titleTextColor="@color/white"
                     app:title="@string/library_title"/>
 
                 <include

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -43,6 +43,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="bottom"
                     app:tabIndicatorHeight="3dp"
+                    app:tabTextColor="@color/colorAccent"
                     android:tag=":aesthetic_ignore"
                     app:tabMode="scrollable"/>
 

--- a/app/src/main/res/layout/fragment_mini_player.xml
+++ b/app/src/main/res/layout/fragment_mini_player.xml
@@ -30,7 +30,6 @@
         android:ellipsize="end"
         android:gravity="center_vertical"
         android:lines="1"
-        android:tag=":aesthetic_ignore"
         android:textColor="?android:textColorSecondary"
         android:textSize="14sp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -25,6 +25,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 android:background="?colorPrimary"
+                android:tag=":aesthetic_ignore"
                 app:contentInsetStartWithNavigation="0dp"/>
 
             <include

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -18,6 +18,7 @@
         android:layout_height="?attr/actionBarSize"
         android:background="@color/colorPrimary"
         android:tag=":aesthetic_ignore"
+        app:titleTextColor="@color/white"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -21,10 +21,14 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
-
+        <item name="actionOverflowButtonStyle">@style/MyOverflowButtonStyle</item>
         <item name="list_selector">@drawable/list_selector_light</item>
         <item name="listDividerColor">@color/list_divider_light</item>
         <item name="circular_ripple">@drawable/ripple_circular_light</item>
+    </style>
+
+    <style name="MyOverflowButtonStyle" parent="Widget.AppCompat.ActionButton.Overflow">
+        <item name="android:tint">#FFFFFF</item>
     </style>
 
     <style name="CarTheme" parent="AppTheme">


### PR DESCRIPTION
This PR is to fix the bug that causes color camouflage when set to the dark theme mentioned in #60. Please uninstall the previous version of the app and reinstall the new version for accurate results. 

Changes:
Set the default theme to be light upon new installation. (I'm guessing since no default theme was set using the `Aesthetic`, the library was sort of misbehaving while changing themes).

"Closes #60"