### PR TITLE
feat: force theme v2

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme.Light">
 
         <meta-data
             android:name="android.max_aspect"

--- a/app/src/main/java/com/simplecity/amp_library/ui/modelviews/FolderView.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/modelviews/FolderView.java
@@ -271,11 +271,13 @@ public class FolderView extends BaseSelectableViewModel<FolderView.ViewHolder> {
             overflow.setOnClickListener(v -> viewModel.onOverflowClick(v));
             checkBox.setOnClickListener(v -> viewModel.onCheckboxClick((CheckBox) v));
 
+            int colorPrimary = Aesthetic.get(itemView.getContext()).colorPrimary().blockingFirst();
+
             folderDrawable = ContextCompat.getDrawable(itemView.getContext(), R.drawable.ic_folder_24dp);
             parentFolderDrawable = ContextCompat.getDrawable(itemView.getContext(), R.drawable.ic_folder_outline);
             fileDrawable = ContextCompat.getDrawable(itemView.getContext(), R.drawable.ic_headphones_white);
 
-            imageView.setColorFilter(R.color.colorPrimary);
+            imageView.setColorFilter(colorPrimary);
         }
 
         @Override

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/drawer/DrawerFragment.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/drawer/DrawerFragment.kt
@@ -141,10 +141,16 @@ class DrawerFragment : BaseFragment(), DrawerView, View.OnCreateContextMenuListe
     override fun onResume() {
         super.onResume()
 
+        // Todo: Move this crap to presenter
+        disposables.add(Aesthetic.get(context)
+            .colorPrimary()
+            .compose(Rx.distinctToMainThread())
+            .subscribe { color ->
+                backgroundPlaceholder!!.setColorFilter(color!!, PorterDuff.Mode.MULTIPLY)
                 if (mediaManager.song == null) {
                     background_image.setImageDrawable(backgroundPlaceholder)
                 }
-
+            })
 
         playerPresenter.updateTrackInfo()
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/folders/FolderFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/folders/FolderFragment.java
@@ -227,6 +227,11 @@ public class FolderFragment extends BaseFragment implements
         recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
         recyclerView.setAdapter(adapter);
 
+        compositeDisposable.add(Aesthetic.get(getContext())
+                .colorPrimary()
+                .compose(distinctToMainThread())
+                .subscribe(color -> ViewBackgroundAction.create(appBarLayout).accept(color), onErrorLogAndRethrow()));
+
         return rootView;
     }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/main/LibraryController.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/main/LibraryController.java
@@ -110,6 +110,8 @@ public class LibraryController extends BaseFragment implements
     @Inject
     AnalyticsManager analyticsManager;
 
+    private CompositeDisposable compositeDisposable = new CompositeDisposable();
+
     private Disposable tabChangedDisposable;
 
     private Unbinder unbinder;
@@ -146,6 +148,12 @@ public class LibraryController extends BaseFragment implements
 
         setupViewPager();
 
+        compositeDisposable.add(Aesthetic.get(getContext())
+                .colorPrimary()
+                .compose(distinctToMainThread())
+                .subscribe(color -> ViewBackgroundAction.create(appBarLayout)
+                        .accept(color), onErrorLogAndRethrow()));
+
         return rootView;
     }
 
@@ -172,6 +180,7 @@ public class LibraryController extends BaseFragment implements
     @Override
     public void onDestroyView() {
         pager.setAdapter(null);
+        compositeDisposable.clear();
         unbinder.unbind();
         super.onDestroyView();
     }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/main/MainActivity.java
@@ -79,6 +79,7 @@ public class MainActivity extends BaseActivity implements
     @Inject
     SettingsManager settingsManager;
 
+    @SuppressLint("ResourceType")
     @Override
     public void onCreate(Bundle savedInstanceState) {
         AndroidInjection.inject(this);
@@ -87,6 +88,19 @@ public class MainActivity extends BaseActivity implements
         analyticsManager.dropBreadcrumb(TAG, "onCreate()");
 
         setContentView(R.layout.activity_main);
+
+        // If we haven't set any defaults, do that now
+        if (Aesthetic.isFirstTime(this)) {
+
+            Aesthetic.get(this)
+                    .activityTheme(R.style.AppTheme_Light)
+                    .isDark(false)
+                    .colorPrimaryRes(R.color.colorPrimary)
+                    .colorAccentRes(R.color.colorAccent)
+                    .colorStatusBarAuto()
+                    .apply();
+
+        }
 
         Permiso.getInstance().setActivity(this);
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsParentFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsParentFragment.java
@@ -274,6 +274,14 @@ public class SettingsParentFragment extends BaseNavigationController implements
                 });
             }
 
+            Preference setDefaultThemePreference = findPreference(SettingsManager.KEY_PREF_SET_DEFAULT_THEME);
+            if (setDefaultThemePreference != null){
+                setDefaultThemePreference.setOnPreferenceClickListener(preference -> {
+                    settingsPresenter.setDefaultThemeClicked(getContext());
+                    return true;
+                });
+            }
+
             SwitchPreferenceCompat tintNavBarColorPreference = (SwitchPreferenceCompat) findPreference(SettingsManager.KEY_PREF_NAV_BAR);
             if (tintNavBarColorPreference != null) {
                 tintNavBarColorPreference.setOnPreferenceChangeListener((preference, newValue) -> {

--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsPresenter.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsPresenter.java
@@ -213,8 +213,8 @@ public class SettingsPresenter extends PurchasePresenter<SettingsView> {
     public void usePaletteNowPlayingOnlyClicked(Context context, boolean usePaletteNowPlayingOnly) {
         // If we're only using palette for 'now playing', set the primary color back to default
         if (usePaletteNowPlayingOnly) {
-            int storedPrimaryColor = settingsManager.getPrimaryColor();
-            int storedAccentColor = settingsManager.getAccentColor();
+            int storedPrimaryColor = context.getResources().getColor(R.color.colorPrimary);
+            int storedAccentColor = context.getResources().getColor(R.color.colorAccent);
 
             Aesthetic.get(context)
                     .colorPrimary(storedPrimaryColor == -1 ? ContextCompat.getColor(context, R.color.md_blue_500) : storedPrimaryColor)

--- a/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsPresenter.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/settings/SettingsPresenter.java
@@ -167,6 +167,18 @@ public class SettingsPresenter extends PurchasePresenter<SettingsView> {
         settingsManager.storePrimaryColor(color);
     }
 
+    public void setDefaultThemeClicked(Context context){
+        int storedPrimaryColor = context.getResources().getColor(R.color.colorPrimary);
+        int storedAccentColor = context.getResources().getColor(R.color.colorAccent);
+
+        Aesthetic.get(context)
+                .colorPrimary(storedPrimaryColor == -1 ? ContextCompat.getColor(context, R.color.md_blue_500) : storedPrimaryColor)
+                .colorAccent(storedAccentColor == -1 ? ContextCompat.getColor(context, R.color.md_amber_300) : storedAccentColor)
+                .colorStatusBarAuto()
+                .colorNavigationBarAuto(settingsManager.getTintNavBar())
+                .apply();
+    }
+
     public void accentColorClicked(Context context) {
         SettingsView settingsView = getView();
         if (settingsView != null) {

--- a/app/src/main/java/com/simplecity/amp_library/ui/views/BreadcrumbView.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/views/BreadcrumbView.java
@@ -37,6 +37,8 @@ public class BreadcrumbView extends RelativeLayout implements Breadcrumb, OnClic
 
     private List<BreadcrumbListener> mBreadcrumbListeners;
 
+    private Disposable aestheticDisposable;
+
     /**
      * Constructor of <code>BreadcrumbView</code>
      */
@@ -88,10 +90,23 @@ public class BreadcrumbView extends RelativeLayout implements Breadcrumb, OnClic
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
+
+        Aesthetic.get(getContext())
+                .colorPrimary()
+                .take(1)
+                .subscribe(color -> ViewBackgroundAction.create(this)
+                        .accept(color), onErrorLogAndRethrow());
+
+        aestheticDisposable = (Aesthetic.get(getContext())
+                .colorPrimary()
+                .compose(distinctToMainThread())
+                .subscribe(color -> ViewBackgroundAction.create(this)
+                        .accept(color), onErrorLogAndRethrow()));
     }
 
     @Override
     protected void onDetachedFromWindow() {
+        aestheticDisposable.dispose();
         super.onDetachedFromWindow();
     }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/views/ThemedStatusBarView.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/views/ThemedStatusBarView.java
@@ -12,6 +12,8 @@ import static com.afollestad.aesthetic.Rx.onErrorLogAndRethrow;
 
 public class ThemedStatusBarView extends StatusBarView {
 
+    private Disposable bgSubscription;
+
     public ThemedStatusBarView(Context context) {
         super(context);
     }
@@ -38,10 +40,23 @@ public class ThemedStatusBarView extends StatusBarView {
         // So, we'll just do a take(1), and since we're calling from the main thread, we don't need to worry
         // about distinctToMainThread() for this call. This prevents the 'flickering' of colors.
 
+        Aesthetic.get(getContext())
+                .colorStatusBar()
+                .take(1)
+                .subscribe(
+                        ViewBackgroundAction.create(this), onErrorLogAndRethrow()
+                );
+
+        bgSubscription = Aesthetic.get(getContext()).colorStatusBar()
+                .compose(Rx.distinctToMainThread())
+                .subscribe(
+                        ViewBackgroundAction.create(this), onErrorLogAndRethrow()
+                );
     }
 
     @Override
     protected void onDetachedFromWindow() {
+        bgSubscription.dispose();
         super.onDetachedFromWindow();
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/utils/SettingsManager.java
+++ b/app/src/main/java/com/simplecity/amp_library/utils/SettingsManager.java
@@ -41,6 +41,8 @@ public class SettingsManager extends BaseSettingsManager {
     public static String KEY_PREF_NAV_BAR = "pref_nav_bar";
     public static String KEY_PREF_PALETTE = "pref_theme_use_palette";
     public static String KEY_PREF_PALETTE_NOW_PLAYING_ONLY = "pref_theme_use_palette_now_playing";
+    public static String KEY_PREF_SET_DEFAULT_THEME = "pref_default_theme";
+
 
     // Artwork
     public static String KEY_PREF_DOWNLOAD_ARTWORK = "pref_download_artwork";

--- a/app/src/main/res/layout/fragment_equalizer.xml
+++ b/app/src/main/res/layout/fragment_equalizer.xml
@@ -20,7 +20,6 @@
         android:minHeight="?attr/actionBarSize"
         android:title="@string/equalizer"
         android:transitionName="toolbar"
-        android:tag=":aesthetic_ignore"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
         app:theme="?attr/toolbar_theme"/>

--- a/app/src/main/res/layout/fragment_folder_browser.xml
+++ b/app/src/main/res/layout/fragment_folder_browser.xml
@@ -46,7 +46,6 @@
                     android:layout_height="?attr/actionBarSize"
                     android:transitionName="toolbar"
                     app:layout_collapseMode="none"
-                    android:tag=":aesthetic_ignore"
                     app:navigationIcon="?attr/homeAsUpIndicator"
                     app:title="@string/folders_title"/>
 

--- a/app/src/main/res/layout/fragment_library.xml
+++ b/app/src/main/res/layout/fragment_library.xml
@@ -43,7 +43,6 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="bottom"
                     app:tabIndicatorHeight="3dp"
-                    android:tag=":aesthetic_ignore"
                     app:tabMode="scrollable"/>
 
                 <android.support.v7.widget.Toolbar
@@ -52,8 +51,6 @@
                     android:layout_height="?attr/actionBarSize"
                     android:transitionName="toolbar"
                     app:layout_collapseMode="none"
-                    android:tag=":aesthetic_ignore"
-
                     app:title="@string/library_title"/>
 
                 <include

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -17,7 +17,6 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="@color/colorPrimary"
-        android:tag=":aesthetic_ignore"
         app:navigationIcon="?attr/homeAsUpIndicator"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
 

--- a/app/src/main/res/layout/list_item_drawer.xml
+++ b/app/src/main/res/layout/list_item_drawer.xml
@@ -65,6 +65,7 @@
             android:layout_marginRight="16dp"
             android:fontFamily="sans-serif"
             android:gravity="center"
+            android:textColor="?colorPrimary"
             android:visibility="gone"
             tools:text="00:00"
             tools:visibility="visible"/>

--- a/app/src/main/res/layout/list_item_folder.xml
+++ b/app/src/main/res/layout/list_item_folder.xml
@@ -17,7 +17,6 @@
         android:layout_marginLeft="16dp"
         android:layout_marginStart="16dp"
         android:src="@drawable/ic_folder_24dp"
-        android:tag=":aesthetic_ignore"
         app:border_width="8dp"/>
 
     <CheckBox
@@ -25,7 +24,6 @@
         android:layout_width="34dp"
         android:layout_height="48dp"
         android:layout_marginLeft="8dp"
-        android:tag=":aesthetic_ignore"
         android:visibility="gone"/>
 
     <FrameLayout
@@ -45,7 +43,6 @@
             android:gravity="center_vertical"
             android:maxLines="2"
             android:textSize="14sp"
-            android:tag=":aesthetic_ignore"
             tools:text="Franz Ferdinand - Feeling Kind Of Anxious.mp3"/>
 
         <LinearLayout
@@ -79,7 +76,6 @@
                 android:layout_weight="1"
                 android:ellipsize="end"
                 android:gravity="center_vertical"
-                android:tag=":aesthetic_ignore"
                 android:maxLines="1"
                 android:textSize="14sp"
                 tools:text="Franz Ferdinand - Tonight"/>
@@ -96,7 +92,6 @@
         android:maxLines="1"
         android:minEms="3"
         android:textSize="14sp"
-        android:tag=":aesthetic_ignore"
         tools:text="3:52"/>
 
     <include layout="@layout/overflow_button"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,8 +284,10 @@
     <!-- Settings title for the themes -->
     <string name="pref_string_title_themes">Themes</string>
     <!-- Setting title for set default theme preference-->
+    <!-- TODO to translate -->
     <string name = "pref_string_set_default_theme">Set Default theme</string>
     <!-- Summary of set default theme preference-->
+    <!-- TODO to translate -->
     <string name = "pref_summary_set_default_theme">Sets the theme of the app back to the default MUSER color</string>
     <!--Settings titles for the themes -->
     <string name="pref_title_base_theme">Base Theme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -283,6 +283,10 @@
     <string name="pref_summary_tinted_nav">Enable/disable the navigation bar tint</string>
     <!-- Settings title for the themes -->
     <string name="pref_string_title_themes">Themes</string>
+    <!-- Setting title for set default theme preference-->
+    <string name = "pref_string_set_default_theme">Set Default theme</string>
+    <!-- Summary of set default theme preference-->
+    <string name = "pref_summary_set_default_theme">Sets the theme of the app back to the default MUSER color</string>
     <!--Settings titles for the themes -->
     <string name="pref_title_base_theme">Base Theme</string>
     <string name="pref_summary_base_theme">Choose your base theme (light or dark)</string>

--- a/app/src/main/res/xml/settings_themes.xml
+++ b/app/src/main/res/xml/settings_themes.xml
@@ -23,6 +23,11 @@
             android:summary="@string/pref_summary_theme_pick_accent_color"
             android:title="@string/pref_title_theme_pick_accent_color"/>
 
+        <android.support.v7.preference.Preference
+            android:key="pref_default_theme"
+            android:summary="@string/pref_summary_set_default_theme"
+            android:title="@string/pref_string_set_default_theme"/>
+
         <android.support.v7.preference.SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="pref_nav_bar"

--- a/app/src/main/res/xml/settings_themes.xml
+++ b/app/src/main/res/xml/settings_themes.xml
@@ -33,7 +33,8 @@
     </android.support.v7.preference.PreferenceCategory>
 
     <android.support.v7.preference.PreferenceCategory
-        android:title="@string/pref_group_palette">
+        android:title="@string/pref_group_palette"
+        app:isPreferenceVisible="false">
 
         <android.support.v7.preference.SwitchPreferenceCompat
             android:defaultValue="true"
@@ -44,6 +45,7 @@
         <android.support.v7.preference.SwitchPreferenceCompat
             android:dependency="pref_theme_use_palette"
             android:key="pref_theme_use_palette_now_playing"
+            android:defaultValue="true"
             android:title="@string/pref_title_palette_now_playing"/>
 
     </android.support.v7.preference.PreferenceCategory>


### PR DESCRIPTION
This PR is to force the default MUSER colors to the app by setting the "Only on Now-Playing Screen" at all times. This PR also allows the user to customize themes and set the default theme on one click. 

Changes include:-

- [x] Revert the last force theme PR.
- [x] Set the now playing preference to be true by default and make the preference invisible. 
- [x] Set the default theme of the App to be `AppTheme.Light`
- [x] Add a preference click that sets the default theme in one click. Found Settings -> Themes -> Set Default Theme

"Closes #60"