### PR TITLE
chore: Bump version name and code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
         targetSdkVersion Dependencies.targetSdk
 
         versionName Config.versionName
-        versionCode 5001
+        versionCode 5002
 
         resConfigs "en", "zh-rCN", "fr", "de", "ko", "it", "ru", "nl", "tr", "pl", "ro", "hu", "hi-rIN", "uk", "bg-rBG", "en-rGB", "et-rEE", "vi", "pt-rBR", "es", "en-rNZ", "zh-rTW", "es-rES", "ca", "hr", "en-rAU", "eu-rES", "th", "ja"
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,5 +1,5 @@
 object Config {
 
-    const val versionName = "1.0.0"
+    const val versionName = "1.1.0"
 
 }


### PR DESCRIPTION
This PR is to bump `versionName` and `versionCode` for beta release on Google Play Store. 

`versionName 1.1.0` `versionCode 5002`

Enhancements:

- #17 - Add Song Data Pojo (PR #41)
- #47 - Set default theme (PR #48)
- #42 - Add adaptive icons(PR #51)
- Add full adaptive icons source (PR #52)
- Remove old adaptive icon source file
- #60 - Force theme colors (PR #63)
- #46 - Initial implementation of tracking PLAY and PAUSE events via Firebase(PR #66)
- #62 - New adaptive icons, add feature graphic (PR #67)
- #38, #39 -  Dialogs and IO for participant registration process(PR #64)
- #68 - updated README.md with build and release instructions(PR #73)