### PR TITLE
chore: Removed class name obfuscation

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -7,7 +7,6 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
-
 # Don't rename class names - this makes stack traces much easier to read/troubleshoot
 -dontobfuscate
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -7,6 +7,10 @@
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
+
+# Don't rename class names - this makes stack traces much easier to read/troubleshoot
+-dontobfuscate
+
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
 -keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
This PR is to remove class name obfuscation to make stack traces much easier to read/troubleshoot.

See https://github.com/CUTR-at-USF/MUSER/issues/78