### PR TITLE
chore: bump versionName (5003) and versionCode (1.1.1)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
         targetSdkVersion Dependencies.targetSdk
 
         versionName Config.versionName
-        versionCode 5002
+        versionCode 5003
 
         resConfigs "en", "zh-rCN", "fr", "de", "ko", "it", "ru", "nl", "tr", "pl", "ro", "hu", "hi-rIN", "uk", "bg-rBG", "en-rGB", "et-rEE", "vi", "pt-rBR", "es", "en-rNZ", "zh-rTW", "es-rES", "ca", "hr", "en-rAU", "eu-rES", "th", "ja"
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,5 +1,5 @@
 object Config {
 
-    const val versionName = "1.1.0"
+    const val versionName = "1.1.1"
 
 }


### PR DESCRIPTION
This PR is to bump `versionName `and `versionCode `for beta release on Google Play Store.
 `versionName 1.1.1` versionCode `5003`

Enhancements:

- #78 - Removed class name obfuscation(PR #80)

Bugs:

- #78 - Keep song model classes when obfuscating(PR #79)
