### PR TITLE
chore: Append version to release APK file name

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,6 +104,14 @@ android {
 
             buildConfigField("String", "LASTFM_API_KEY", "\"${getProperty(getProperties('../private.properties'), 'LASTFM_API_KEY')}\"")
         }
+      // Append the version name to the end of aligned APKs
+      android.applicationVariants.all { variant ->
+        if (variant.buildType.name == "release") {
+          variant.outputs.all { output ->
+            outputFileName = "${variant.name}-v${variant.versionName}.apk"
+          }
+        }
+      }
     }
 
     // Ignore useless variants, such as devRelease.


### PR DESCRIPTION
With this patch, the `versionName` is automatically appended to the release APK file name. This will make it easier for us to track which version a particular filename release was.

For example, the new file name is:

`freeRelease-v1.1.1.apk`

...instead of:

`freeRelease.apk`

@BumbleFlash When you get a chance, could you please do some testing on this release build to make sure this PR doesn't break anything? I've tested that the file name is generated but haven't run the APK as an update, etc. on my device to make sure it works correctly at runtime. It also shouldn't have any impact on debug builds (file name is only changed on release builds).

I've used this same technique in several other projects, although I don't know if MUSER/Shuttle is doing something special in release builds that this could potentially break.