### PR TITLE
chore: change targetsdk and compilesdk to 29

### DIFF
--- a/buildSrc/src/main/kotlin/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/dependencies/Dependencies.kt
@@ -3,8 +3,8 @@ package dependencies
 object Dependencies {
 
     const val minSdk = 21
-    const val targetSdk = 28
-    const val compileSdk = 28
+    const val targetSdk = 29
+    const val compileSdk = 29
 
     object Versions {
         const val nanoHttp = "2.3.1"


### PR DESCRIPTION
This PR is to change the API level to 29. 

"closes #77"