### PR TITLE
chore: bump versionCode(5004) and versionName(1.1.2)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
         targetSdkVersion Dependencies.targetSdk
 
         versionName Config.versionName
-        versionCode 5003
+        versionCode 5004
 
         resConfigs "en", "zh-rCN", "fr", "de", "ko", "it", "ru", "nl", "tr", "pl", "ro", "hu", "hi-rIN", "uk", "bg-rBG", "en-rGB", "et-rEE", "vi", "pt-rBR", "es", "en-rNZ", "zh-rTW", "es-rES", "ca", "hr", "en-rAU", "eu-rES", "th", "ja"
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,5 +1,5 @@
 object Config {
 
-    const val versionName = "1.1.1"
+    const val versionName = "1.1.2"
 
 }


### PR DESCRIPTION
This PR is to bump `versionName` and `versionCode` for beta release on Google Play Store.
versionName `1.1.2` versionCode `5004`

Enhancements:
- #77 - Change targetsdk and compilesdk to 29 (#86)