### PR TITLE
feat: Add NEXT event

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
@@ -41,7 +41,6 @@ import com.simplecity.amp_library.utils.SettingsManager;
 import com.simplecity.amp_library.utils.ShuttleUtils;
 import com.simplecity.amp_library.utils.playlists.FavoritesPlaylistManager;
 import dagger.android.AndroidInjection;
-import edu.usf.sas.pal.muser.model.PlayerEventType;
 import edu.usf.sas.pal.muser.model.UiEvent;
 import edu.usf.sas.pal.muser.model.UiEventType;
 import edu.usf.sas.pal.muser.util.EventUtils;
@@ -371,7 +370,7 @@ public class MusicService extends MediaBrowserServiceCompat {
 
                         // Possible solution: (A) Show the Shuttle notification, despite the fact that music isn't playing. Need to customise notification to allow for an empty queue (no current song)
                         // We could try to generate a queue of random songs as well, but there's no guarantee the user has music on their device.
-                        newUiEvent(queueManager.getCurrentSong(), UiEventType.SKIP);
+                        newUiEvent(queueManager.getCurrentSong(), UiEventType.NEXT);
                         gotoNext(true);
 
                         break;

--- a/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
@@ -371,7 +371,7 @@ public class MusicService extends MediaBrowserServiceCompat {
 
                         // Possible solution: (A) Show the Shuttle notification, despite the fact that music isn't playing. Need to customise notification to allow for an empty queue (no current song)
                         // We could try to generate a queue of random songs as well, but there's no guarantee the user has music on their device.
-
+                        newUiEvent(queueManager.getCurrentSong(), UiEventType.SKIP);
                         gotoNext(true);
 
                         break;

--- a/app/src/main/java/com/simplecity/amp_library/playback/PlaybackManager.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/PlaybackManager.java
@@ -482,7 +482,7 @@ public class PlaybackManager implements Playback.Callbacks {
      * @return true if the we've successfully moved to the next track.
      */
     public boolean next(boolean force) {
-        newPlayerEvent(queueManager.getCurrentSong(), PlayerEventType.SKIP);
+        newPlayerEvent(queueManager.getCurrentSong(), PlayerEventType.NEXT);
         notifyChange(InternalIntents.TRACK_ENDING);
 
         int nextPosition = getNextPosition(force);

--- a/app/src/main/java/com/simplecity/amp_library/playback/PlaybackManager.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/PlaybackManager.java
@@ -482,6 +482,7 @@ public class PlaybackManager implements Playback.Callbacks {
      * @return true if the we've successfully moved to the next track.
      */
     public boolean next(boolean force) {
+        newPlayerEvent(queueManager.getCurrentSong(), PlayerEventType.SKIP);
         notifyChange(InternalIntents.TRACK_ENDING);
 
         int nextPosition = getNextPosition(force);
@@ -491,6 +492,7 @@ public class PlaybackManager implements Playback.Callbacks {
         }
 
         setQueuePosition(nextPosition);
+        newPlayerEvent(queueManager.getCurrentSong(), PlayerEventType.PLAY);
         return true;
     }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerFragment.java
@@ -771,7 +771,7 @@ public class PlayerFragment extends BaseFragment implements
     }
 
     @Nullable
-    private Song getSong() {
+    public static Song getSong() {
         if (MusicServiceConnectionUtils.serviceBinder != null && MusicServiceConnectionUtils.serviceBinder.getService() != null) {
             return MusicServiceConnectionUtils.serviceBinder.getService().getSong();
         }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerPresenter.kt
@@ -3,6 +3,7 @@ package com.simplecity.amp_library.ui.screens.nowplaying
 import android.app.Activity
 import android.content.Context
 import android.content.IntentFilter
+import android.util.Log
 import com.cantrowitz.rxbroadcast.RxBroadcast
 import com.simplecity.amp_library.ShuttleApplication
 import com.simplecity.amp_library.playback.MediaManager
@@ -10,11 +11,15 @@ import com.simplecity.amp_library.playback.PlaybackMonitor
 import com.simplecity.amp_library.playback.constants.InternalIntents
 import com.simplecity.amp_library.ui.common.Presenter
 import com.simplecity.amp_library.ui.screens.songs.menu.SongMenuPresenter
+import com.simplecity.amp_library.utils.FileHelper.getSong
 import com.simplecity.amp_library.utils.LogUtils
 import com.simplecity.amp_library.utils.SettingsManager
 import com.simplecity.amp_library.utils.ShuttleUtils
 import com.simplecity.amp_library.utils.menu.song.SongsMenuCallbacks
 import com.simplecity.amp_library.utils.playlists.FavoritesPlaylistManager
+import edu.usf.sas.pal.muser.model.UiEventType
+import edu.usf.sas.pal.muser.util.EventUtils
+import edu.usf.sas.pal.muser.util.FirebaseIOUtils
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -184,6 +189,7 @@ class PlayerPresenter @Inject constructor(
     }
 
     fun skip() {
+        saveUiEvent(UiEventType.SKIP)
         mediaManager.next()
     }
 
@@ -295,5 +301,12 @@ class PlayerPresenter @Inject constructor(
     companion object {
 
         private const val TAG = "PlayerPresenter"
+    }
+
+    fun saveUiEvent(uiEventType: UiEventType){
+        if (PlayerFragment.getSong() != null) {
+            val uiEvent = EventUtils.newUiEvent(PlayerFragment.getSong(), uiEventType, context)
+            FirebaseIOUtils.saveUiEvent(uiEvent)
+        }
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerPresenter.kt
@@ -3,7 +3,6 @@ package com.simplecity.amp_library.ui.screens.nowplaying
 import android.app.Activity
 import android.content.Context
 import android.content.IntentFilter
-import android.util.Log
 import com.cantrowitz.rxbroadcast.RxBroadcast
 import com.simplecity.amp_library.ShuttleApplication
 import com.simplecity.amp_library.playback.MediaManager
@@ -11,7 +10,6 @@ import com.simplecity.amp_library.playback.PlaybackMonitor
 import com.simplecity.amp_library.playback.constants.InternalIntents
 import com.simplecity.amp_library.ui.common.Presenter
 import com.simplecity.amp_library.ui.screens.songs.menu.SongMenuPresenter
-import com.simplecity.amp_library.utils.FileHelper.getSong
 import com.simplecity.amp_library.utils.LogUtils
 import com.simplecity.amp_library.utils.SettingsManager
 import com.simplecity.amp_library.utils.ShuttleUtils
@@ -189,7 +187,7 @@ class PlayerPresenter @Inject constructor(
     }
 
     fun skip() {
-        saveUiEvent(UiEventType.SKIP)
+        saveUiEvent(UiEventType.NEXT)
         mediaManager.next()
     }
 

--- a/app/src/main/java/edu/usf/sas/pal/muser/model/PlayerEventType.java
+++ b/app/src/main/java/edu/usf/sas/pal/muser/model/PlayerEventType.java
@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
 public enum PlayerEventType {
         PLAY,
         PAUSE,
-        SKIP,
+        NEXT,
         REPEAT,
         SEEK
 }

--- a/app/src/main/java/edu/usf/sas/pal/muser/model/UiEventType.java
+++ b/app/src/main/java/edu/usf/sas/pal/muser/model/UiEventType.java
@@ -7,7 +7,7 @@ package edu.usf.sas.pal.muser.model;
 public enum UiEventType {
          PLAY,
          PAUSE,
-         SKIP,
+         NEXT,
          REPEAT,
          SEEK,
          CREATE_PLAYLIST,


### PR DESCRIPTION
This PR is to collect `SKIP` event when a user clicks on the SKIP button. 

Changes include:
- [x] Collect UI_EVENT `SKIP` from `PlayerFragment`
- [x] Collect PLAYER_EVENT `SKIP` from `PlaybackManager`
- [x] Collect PLAYER_EVENT `PLAY` from `PlaybackManager`, as soon as the next song is played.
- [x] Collect UI_EVENT `SKIP` from notification bar. 

Reference - https://github.com/CUTR-at-USF/MUSER/issues/17