### PR TITLE
feat: Add PREV event

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
@@ -382,7 +382,7 @@ public class MusicService extends MediaBrowserServiceCompat {
                         // - No queue: ANR
 
                         // Possible solution: (A) Show the Shuttle notification, despite the fact that music isn't playing. Need to customise notification to allow for an empty queue (no current song)
-
+                        newUiEvent(queueManager.getCurrentSong(), UiEventType.PREV);
                         previous(false);
 
                         break;

--- a/app/src/main/java/com/simplecity/amp_library/playback/PlaybackManager.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/PlaybackManager.java
@@ -500,10 +500,12 @@ public class PlaybackManager implements Playback.Callbacks {
      * @param force true to ignore the current seek position & repeat mode.
      */
     public void previous(boolean force) {
+        newPlayerEvent(queueManager.getCurrentSong(), PlayerEventType.PREV);
         if (force || getSeekPosition() <= 2000) {
             queueManager.previous();
             stop(false);
             load(false, true, 0);
+            newPlayerEvent(queueManager.getCurrentSong(), PlayerEventType.PLAY);
         } else {
             seekTo(0);
             play();

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerPresenter.kt
@@ -193,6 +193,7 @@ class PlayerPresenter @Inject constructor(
     }
 
     fun prev(force: Boolean) {
+        saveUiEvent(UiEventType.PREV)
         mediaManager.previous(force)
     }
 

--- a/app/src/main/java/edu/usf/sas/pal/muser/model/PlayerEventType.java
+++ b/app/src/main/java/edu/usf/sas/pal/muser/model/PlayerEventType.java
@@ -11,5 +11,6 @@ public enum PlayerEventType {
         PAUSE,
         NEXT,
         REPEAT,
-        SEEK
+        SEEK,
+        PREV
 }

--- a/app/src/main/java/edu/usf/sas/pal/muser/model/UiEventType.java
+++ b/app/src/main/java/edu/usf/sas/pal/muser/model/UiEventType.java
@@ -11,6 +11,7 @@ public enum UiEventType {
          PLAY_GENRE,
          PAUSE,
          NEXT,
+         PREV,
          REPEAT,
          SEEK,
          CREATE_PLAYLIST,


### PR DESCRIPTION
This PR is to capture the `PREV` event when the user clicks on the previous button. 

Changes include:-
 
- [x] Collect UI_EVENT SKIP from PlayerFragment
- [x] Collect PLAYER_EVENT SKIP from PlaybackManager
- [x] Collect PLAYER_EVENT PLAY from PlaybackManager, as soon as the prev song is played.
- [x] Collect UI_EVENT SKIP from the notification bar.