### PR TITLE
feat: add favorite or unfavorite tracking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:theme="@style/AppTheme.Light">
+        android:theme="@style/AppTheme.Light"
+        android:requestLegacyExternalStorage="true">
 
         <meta-data
             android:name="android.max_aspect"

--- a/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
@@ -805,8 +805,10 @@ public class MusicService extends MediaBrowserServiceCompat {
             favoritesPlaylistManager.toggleFavorite(song, isFavorite -> {
                 if (isFavorite) {
                     Toast.makeText(MusicService.this, getString(R.string.song_to_favourites, song.name), Toast.LENGTH_SHORT).show();
+                    newUiEvent(queueManager.getCurrentSong(), UiEventType.FAVORITE);
                 } else {
                     Toast.makeText(MusicService.this, getString(R.string.song_removed_from_favourites, song.name), Toast.LENGTH_SHORT).show();
+                    newUiEvent(queueManager.getCurrentSong(), UiEventType.UNFAVORITE);
                 }
                 notifyChange(InternalIntents.FAVORITE_CHANGED);
                 return Unit.INSTANCE;

--- a/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
+++ b/app/src/main/java/com/simplecity/amp_library/playback/MusicService.java
@@ -805,10 +805,10 @@ public class MusicService extends MediaBrowserServiceCompat {
             favoritesPlaylistManager.toggleFavorite(song, isFavorite -> {
                 if (isFavorite) {
                     Toast.makeText(MusicService.this, getString(R.string.song_to_favourites, song.name), Toast.LENGTH_SHORT).show();
-                    newUiEvent(queueManager.getCurrentSong(), UiEventType.FAVORITE);
+                    newUiEvent(song, UiEventType.FAVORITE);
                 } else {
                     Toast.makeText(MusicService.this, getString(R.string.song_removed_from_favourites, song.name), Toast.LENGTH_SHORT).show();
-                    newUiEvent(queueManager.getCurrentSong(), UiEventType.UNFAVORITE);
+                    newUiEvent(song, UiEventType.UNFAVORITE);
                 }
                 notifyChange(InternalIntents.FAVORITE_CHANGED);
                 return Unit.INSTANCE;

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/album/menu/AlbumMenuPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/album/menu/AlbumMenuPresenter.kt
@@ -44,7 +44,7 @@ class AlbumMenuPresenter @Inject constructor(
         getSongs(albums) { songs ->
             if (playlist.type == Playlist.Type.FAVORITES) {
                 songs.forEach {
-                    newUiEvent(UiEventType.FAVORITE, it)
+                    newUiEvent(it)
                 }
             }
             playlistManager.addToPlaylist(playlist, songs) { numSongs ->
@@ -71,7 +71,7 @@ class AlbumMenuPresenter @Inject constructor(
 
     override fun play(album: Album) {
         mediaManager.playAll(album.getSongsSingle(songsRepository)) { view?.onPlaybackFailed() }
-        newUiEvent(UiEventType.PLAY_ALBUM, album)
+        newUiAlbumEvent(album)
     }
 
     override fun editTags(album: Album) {
@@ -135,13 +135,13 @@ class AlbumMenuPresenter @Inject constructor(
         const val TAG = "AlbumMenuContract"
     }
 
-    private fun newUiEvent(uiEventType: UiEventType, album: Album){
-            val uiEvent = EventUtils.newUiAlbumEvent(album, uiEventType)
+    private fun newUiAlbumEvent(album: Album){
+            val uiEvent = EventUtils.newUiAlbumEvent(album, UiEventType.PLAY_ALBUM)
             FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 
-    private fun newUiEvent(uiEventType: UiEventType, song: Song){
-        val uiEvent = EventUtils.newUiEvent(song, uiEventType, ShuttleApplication.get())
+    private fun newUiEvent(song: Song){
+        val uiEvent = EventUtils.newUiEvent(song, UiEventType.FAVORITE, ShuttleApplication.get())
         FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/album/menu/AlbumMenuPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/album/menu/AlbumMenuPresenter.kt
@@ -44,7 +44,7 @@ class AlbumMenuPresenter @Inject constructor(
         getSongs(albums) { songs ->
             if (playlist.type == Playlist.Type.FAVORITES) {
                 songs.forEach {
-                    newUiAlbumEvent(UiEventType.FAVORITE, it)
+                    newUiEvent(UiEventType.FAVORITE, it)
                 }
             }
             playlistManager.addToPlaylist(playlist, songs) { numSongs ->
@@ -71,7 +71,7 @@ class AlbumMenuPresenter @Inject constructor(
 
     override fun play(album: Album) {
         mediaManager.playAll(album.getSongsSingle(songsRepository)) { view?.onPlaybackFailed() }
-        newUiAlbumEvent(UiEventType.PLAY_ALBUM, album)
+        newUiEvent(UiEventType.PLAY_ALBUM, album)
     }
 
     override fun editTags(album: Album) {
@@ -135,12 +135,12 @@ class AlbumMenuPresenter @Inject constructor(
         const val TAG = "AlbumMenuContract"
     }
 
-    private fun newUiAlbumEvent(uiEventType: UiEventType, album: Album){
+    private fun newUiEvent(uiEventType: UiEventType, album: Album){
             val uiEvent = EventUtils.newUiAlbumEvent(album, uiEventType)
             FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 
-    private fun newUiAlbumEvent(uiEventType: UiEventType, song: Song){
+    private fun newUiEvent(uiEventType: UiEventType, song: Song){
         val uiEvent = EventUtils.newUiEvent(song, uiEventType, ShuttleApplication.get())
         FirebaseIOUtils.saveUiEvent(uiEvent)
     }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/album/menu/AlbumMenuPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/album/menu/AlbumMenuPresenter.kt
@@ -1,5 +1,6 @@
 package com.simplecity.amp_library.ui.screens.album.menu
 
+import com.simplecity.amp_library.ShuttleApplication
 import com.simplecity.amp_library.data.Repository
 import com.simplecity.amp_library.model.Album
 import com.simplecity.amp_library.model.Playlist
@@ -41,6 +42,11 @@ class AlbumMenuPresenter @Inject constructor(
 
     override fun addAlbumsToPlaylist(playlist: Playlist, albums: List<Album>) {
         getSongs(albums) { songs ->
+            if (playlist.type == Playlist.Type.FAVORITES) {
+                songs.forEach {
+                    newUiAlbumEvent(UiEventType.FAVORITE, it)
+                }
+            }
             playlistManager.addToPlaylist(playlist, songs) { numSongs ->
                 view?.onSongsAddedToPlaylist(playlist, numSongs)
             }
@@ -65,7 +71,7 @@ class AlbumMenuPresenter @Inject constructor(
 
     override fun play(album: Album) {
         mediaManager.playAll(album.getSongsSingle(songsRepository)) { view?.onPlaybackFailed() }
-        newUiEvent(UiEventType.PLAY_ALBUM, album)
+        newUiAlbumEvent(UiEventType.PLAY_ALBUM, album)
     }
 
     override fun editTags(album: Album) {
@@ -129,8 +135,13 @@ class AlbumMenuPresenter @Inject constructor(
         const val TAG = "AlbumMenuContract"
     }
 
-    fun newUiEvent(uiEventType: UiEventType, album: Album){
+    private fun newUiAlbumEvent(uiEventType: UiEventType, album: Album){
             val uiEvent = EventUtils.newUiAlbumEvent(album, uiEventType)
             FirebaseIOUtils.saveUiEvent(uiEvent)
+    }
+
+    private fun newUiAlbumEvent(uiEventType: UiEventType, song: Song){
+        val uiEvent = EventUtils.newUiEvent(song, uiEventType, ShuttleApplication.get())
+        FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/artist/menu/AlbumArtistMenuPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/artist/menu/AlbumArtistMenuPresenter.kt
@@ -46,7 +46,7 @@ class AlbumArtistMenuPresenter @Inject constructor(
         getSongs(albumArtists) { songs ->
             if (playlist.type == Playlist.Type.FAVORITES) {
                 songs.forEach {
-                    newUiEvent(UiEventType.FAVORITE, it)
+                    newUiEvent(it)
                 }
             }
             playlistManager.addToPlaylist(playlist, songs) { numSongs ->
@@ -73,7 +73,7 @@ class AlbumArtistMenuPresenter @Inject constructor(
 
     override fun play(albumArtist: AlbumArtist) {
         mediaManager.playAll(albumArtist.getSongsSingle(songsRepository)) { view?.onPlaybackFailed() }
-        newUiAlbumArtistEvent(UiEventType.PLAY_ALBUM_ARTIST, albumArtist)
+        newUiAlbumArtistEvent(albumArtist)
     }
 
     override fun editTags(albumArtist: AlbumArtist) {
@@ -136,13 +136,13 @@ class AlbumArtistMenuPresenter @Inject constructor(
         const val TAG = "AlbumMenuContract"
     }
 
-    private fun newUiAlbumArtistEvent(uiEventType: UiEventType, albumArtist: AlbumArtist){
-        val uiEvent = EventUtils.newUiAlbumArtistEvent(albumArtist, uiEventType)
+    private fun newUiAlbumArtistEvent(albumArtist: AlbumArtist){
+        val uiEvent = EventUtils.newUiAlbumArtistEvent(albumArtist, UiEventType.PLAY_ALBUM_ARTIST)
         FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 
-    private fun newUiEvent(uiEventType: UiEventType, song: Song){
-        val uiEvent = EventUtils.newUiEvent(song, uiEventType, ShuttleApplication.get())
+    private fun newUiEvent(song: Song){
+        val uiEvent = EventUtils.newUiEvent(song, UiEventType.FAVORITE, ShuttleApplication.get())
         FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/artist/menu/AlbumArtistMenuPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/artist/menu/AlbumArtistMenuPresenter.kt
@@ -1,5 +1,7 @@
 package com.simplecity.amp_library.ui.screens.album.menu
 
+import android.util.Log
+import com.simplecity.amp_library.ShuttleApplication
 import com.simplecity.amp_library.data.Repository
 import com.simplecity.amp_library.model.AlbumArtist
 import com.simplecity.amp_library.model.Playlist
@@ -42,6 +44,11 @@ class AlbumArtistMenuPresenter @Inject constructor(
 
     override fun addArtistsToPlaylist(playlist: Playlist, albumArtists: List<AlbumArtist>) {
         getSongs(albumArtists) { songs ->
+            if (playlist.type == Playlist.Type.FAVORITES) {
+                songs.forEach {
+                    newUiEvent(UiEventType.FAVORITE, it)
+                }
+            }
             playlistManager.addToPlaylist(playlist, songs) { numSongs ->
                 view?.onSongsAddedToPlaylist(playlist, numSongs)
             }
@@ -66,7 +73,7 @@ class AlbumArtistMenuPresenter @Inject constructor(
 
     override fun play(albumArtist: AlbumArtist) {
         mediaManager.playAll(albumArtist.getSongsSingle(songsRepository)) { view?.onPlaybackFailed() }
-        newUiEvent(UiEventType.PLAY_ALBUM_ARTIST, albumArtist)
+        newUiAlbumArtistEvent(UiEventType.PLAY_ALBUM_ARTIST, albumArtist)
     }
 
     override fun editTags(albumArtist: AlbumArtist) {
@@ -129,8 +136,13 @@ class AlbumArtistMenuPresenter @Inject constructor(
         const val TAG = "AlbumMenuContract"
     }
 
-    fun newUiEvent(uiEventType: UiEventType, albumArtist: AlbumArtist){
+    private fun newUiAlbumArtistEvent(uiEventType: UiEventType, albumArtist: AlbumArtist){
         val uiEvent = EventUtils.newUiAlbumArtistEvent(albumArtist, uiEventType)
+        FirebaseIOUtils.saveUiEvent(uiEvent)
+    }
+
+    private fun newUiEvent(uiEventType: UiEventType, song: Song){
+        val uiEvent = EventUtils.newUiEvent(song, uiEventType, ShuttleApplication.get())
         FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/genre/menu/GenreMenuPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/genre/menu/GenreMenuPresenter.kt
@@ -33,7 +33,7 @@ class GenreMenuPresenter @Inject constructor(
         getSongs(genre) { songs ->
             if (playlist.type == Playlist.Type.FAVORITES) {
                 songs.forEach {
-                    newUiEvent(UiEventType.FAVORITE, it)
+                    newUiEvent(it)
                 }
             }
             playlistManager.addToPlaylist(playlist, songs) { numSongs ->
@@ -51,7 +51,7 @@ class GenreMenuPresenter @Inject constructor(
     }
 
     override fun play(genre: Genre) {
-        newUiGenreEvent(UiEventType.PLAY_GENRE, genre)
+        newUiGenreEvent(genre)
         mediaManager.playAll(genre.getSongs(context)) {
             view?.onPlaybackFailed()
         }
@@ -76,13 +76,13 @@ class GenreMenuPresenter @Inject constructor(
                 )
         )
     }
-    private fun newUiGenreEvent(uiEventType: UiEventType, genre: Genre){
-        val uiEvent = EventUtils.newUiGenreEvent(genre, uiEventType)
+    private fun newUiGenreEvent(genre: Genre){
+        val uiEvent = EventUtils.newUiGenreEvent(genre, UiEventType.PLAY_GENRE)
         FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 
-    private fun newUiEvent(uiEventType: UiEventType, song: Song){
-        val uiEvent = EventUtils.newUiEvent(song, uiEventType, ShuttleApplication.get())
+    private fun newUiEvent(song: Song){
+        val uiEvent = EventUtils.newUiEvent(song, UiEventType.FAVORITE, ShuttleApplication.get())
         FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/genre/menu/GenreMenuPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/genre/menu/GenreMenuPresenter.kt
@@ -1,6 +1,7 @@
 package com.simplecity.amp_library.ui.screens.genre.menu
 
 import android.content.Context
+import com.simplecity.amp_library.ShuttleApplication
 import com.simplecity.amp_library.model.Genre
 import com.simplecity.amp_library.model.Playlist
 import com.simplecity.amp_library.model.Song
@@ -30,6 +31,11 @@ class GenreMenuPresenter @Inject constructor(
 
     override fun addToPlaylist(playlist: Playlist, genre: Genre) {
         getSongs(genre) { songs ->
+            if (playlist.type == Playlist.Type.FAVORITES) {
+                songs.forEach {
+                    newUiEvent(UiEventType.FAVORITE, it)
+                }
+            }
             playlistManager.addToPlaylist(playlist, songs) { numSongs ->
                 view?.onSongsAddedToPlaylist(playlist, numSongs)
             }
@@ -45,7 +51,7 @@ class GenreMenuPresenter @Inject constructor(
     }
 
     override fun play(genre: Genre) {
-        newUiEvent(UiEventType.PLAY_GENRE, genre)
+        newUiGenreEvent(UiEventType.PLAY_GENRE, genre)
         mediaManager.playAll(genre.getSongs(context)) {
             view?.onPlaybackFailed()
         }
@@ -70,8 +76,13 @@ class GenreMenuPresenter @Inject constructor(
                 )
         )
     }
-    fun newUiEvent(uiEventType: UiEventType, genre: Genre){
+    private fun newUiGenreEvent(uiEventType: UiEventType, genre: Genre){
         val uiEvent = EventUtils.newUiGenreEvent(genre, uiEventType)
+        FirebaseIOUtils.saveUiEvent(uiEvent)
+    }
+
+    private fun newUiEvent(uiEventType: UiEventType, song: Song){
+        val uiEvent = EventUtils.newUiEvent(song, uiEventType, ShuttleApplication.get())
         FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/songs/menu/SongMenuPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/songs/menu/SongMenuPresenter.kt
@@ -1,6 +1,7 @@
 package com.simplecity.amp_library.ui.screens.songs.menu
 
 import android.content.Context
+import com.simplecity.amp_library.ShuttleApplication
 import com.simplecity.amp_library.data.Repository
 import com.simplecity.amp_library.data.Repository.AlbumArtistsRepository
 import com.simplecity.amp_library.model.Playlist
@@ -13,6 +14,9 @@ import com.simplecity.amp_library.ui.screens.songs.menu.SongMenuContract.View
 import com.simplecity.amp_library.utils.LogUtils
 import com.simplecity.amp_library.utils.RingtoneManager
 import com.simplecity.amp_library.utils.playlists.PlaylistManager
+import edu.usf.sas.pal.muser.model.UiEventType
+import edu.usf.sas.pal.muser.util.EventUtils
+import edu.usf.sas.pal.muser.util.FirebaseIOUtils
 import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -35,6 +39,11 @@ open class SongMenuPresenter @Inject constructor(
     }
 
     override fun addToPlaylist(playlist: Playlist, songs: List<Song>) {
+        if (playlist.type == Playlist.Type.FAVORITES) {
+            songs.forEach {
+                newUiEvent(UiEventType.FAVORITE, it)
+            }
+        }
         playlistManager.addToPlaylist(playlist, songs) { numSongs ->
             view?.onSongsAddedToPlaylist(playlist, numSongs)
         }
@@ -130,5 +139,10 @@ open class SongMenuPresenter @Inject constructor(
 
     companion object {
         const val TAG = "SongMenuPresenter"
+    }
+
+    private fun newUiEvent(uiEventType: UiEventType, song: Song){
+        val uiEvent = EventUtils.newUiEvent(song, uiEventType, ShuttleApplication.get())
+        FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/songs/menu/SongMenuPresenter.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/songs/menu/SongMenuPresenter.kt
@@ -41,7 +41,7 @@ open class SongMenuPresenter @Inject constructor(
     override fun addToPlaylist(playlist: Playlist, songs: List<Song>) {
         if (playlist.type == Playlist.Type.FAVORITES) {
             songs.forEach {
-                newUiEvent(UiEventType.FAVORITE, it)
+                newUiEvent(it)
             }
         }
         playlistManager.addToPlaylist(playlist, songs) { numSongs ->
@@ -141,8 +141,8 @@ open class SongMenuPresenter @Inject constructor(
         const val TAG = "SongMenuPresenter"
     }
 
-    private fun newUiEvent(uiEventType: UiEventType, song: Song){
-        val uiEvent = EventUtils.newUiEvent(song, uiEventType, ShuttleApplication.get())
+    private fun newUiEvent(song: Song){
+        val uiEvent = EventUtils.newUiEvent(song, UiEventType.FAVORITE, ShuttleApplication.get())
         FirebaseIOUtils.saveUiEvent(uiEvent)
     }
 }

--- a/app/src/main/java/edu/usf/sas/pal/muser/model/UiEventType.java
+++ b/app/src/main/java/edu/usf/sas/pal/muser/model/UiEventType.java
@@ -15,6 +15,8 @@ public enum UiEventType {
          REPEAT_OFF,
          REPEAT_ALL_SONGS,
          REPEAT_CURRENT_SONG,
+         FAVORITE,
+         UNFAVORITE,
          SEEK,
          CREATE_PLAYLIST,
          SELECT_CATEGORY,


### PR DESCRIPTION
This PR is to track two UI_EVENTs `FAVORITE` and `UNFAVORITE`. 
Fixes #101 
Changes include:-

- [x] Add events FAVORITE and UNFAVORITE to `UiEventType`.
- [x] Capture Events from `PlayerFragment` and Notification bar.
- [x] Requested Legacy External Storage to temporarily opt-out of the changes associated with scoped storage, such as granting access to different directories and different types of media files.
- [x] Capture FAVORITE while adding an artist, album, genre, or a song to Favorite Playlist