### PR TITLE
chore: bump versionName (5005) and versionCode (1.2.0) 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
         targetSdkVersion Dependencies.targetSdk
 
         versionName Config.versionName
-        versionCode 5004
+        versionCode 5005
 
         resConfigs "en", "zh-rCN", "fr", "de", "ko", "it", "ru", "nl", "tr", "pl", "ro", "hu", "hi-rIN", "uk", "bg-rBG", "en-rGB", "et-rEE", "vi", "pt-rBR", "es", "en-rNZ", "zh-rTW", "es-rES", "ca", "hr", "en-rAU", "eu-rES", "th", "ja"
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,5 +1,5 @@
 object Config {
 
-    const val versionName = "1.1.3"
+    const val versionName = "1.2.0"
 
 }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,5 +1,5 @@
 object Config {
 
-    const val versionName = "1.1.2"
+    const val versionName = "1.1.3"
 
 }


### PR DESCRIPTION
This PR is to bump `versionName `and `versionCode `for beta release on Google Play Store.
 `versionName 1.2.0` versionCode `5005`

Enhancements:

-  #17 - Add NEXT event (#90)
-  #89, #17 - Add UI_EVENT PLAY, PLAY_ARTIST, PLAY_GENRE, PLAY_ALBUM_ARTIST from overflow (#91)
-  #17 - Add PREV event (#92)
-  #17 - Capture REPEAT events (#93)
-  #87 - Add new informed consent (#94)
-  #17 - Add Shuffle event(#95)
-  #17 - Add favorite and unfavorite tracking (#103)

Bugs:
- #101 - Fix Crash when adding to playlist (API 29 bug) (#103) 
- #104 -  Fix crash while adding duplicates to the Playlist (#107)


