### PR TITLE
fix: fix crashed when clicking on the overflow button.

### DIFF
--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/album/detail/AlbumDetailFragment.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/album/detail/AlbumDetailFragment.kt
@@ -420,7 +420,7 @@ class AlbumDetailFragment :
         override fun onSongOverflowClick(position: Int, v: View, song: Song) {
             val popupMenu = PopupMenu(v.context, v)
             SongMenuUtils.setupSongMenu(popupMenu, false, false, playlistMenuHelper)
-            popupMenu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(parentFragment as MainController, context!!, song, presenter))
+            popupMenu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(null, context!!, song, presenter))
             popupMenu.show()
         }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/artist/detail/ArtistDetailFragment.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/artist/detail/ArtistDetailFragment.kt
@@ -171,7 +171,7 @@ class ArtistDetailFragment :
         override fun onSongOverflowClick(position: Int, v: View, song: Song) {
             val popupMenu = PopupMenu(v.context, v)
             SongMenuUtils.setupSongMenu(popupMenu, false, true, playlistMenuHelper)
-            popupMenu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(parentFragment as MainController,
+            popupMenu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(null,
                     context!!, song, presenter))
             popupMenu.show()
         }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/genre/detail/GenreDetailFragment.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/genre/detail/GenreDetailFragment.kt
@@ -466,7 +466,7 @@ class GenreDetailFragment :
         override fun onSongOverflowClick(position: Int, v: View, song: Song) {
             val popupMenu = PopupMenu(v.context, v)
             SongMenuUtils.setupSongMenu(popupMenu, false, true, playlistMenuHelper)
-            popupMenu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(parentFragment as MainController,
+            popupMenu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(null,
                     context!!, song, presenter))
             popupMenu.show()
         }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerFragment.java
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/nowplaying/PlayerFragment.java
@@ -618,7 +618,7 @@ public class PlayerFragment extends BaseFragment implements
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         if (getContext() != null) {
-            if (!SongMenuUtils.INSTANCE.getSongMenuClickListener((MainController) getParentFragment(), getContext(), mediaManager.getSong(), presenter).onMenuItemClick(item)) {
+            if (!SongMenuUtils.INSTANCE.getSongMenuClickListener(null, getContext(), mediaManager.getSong(), presenter).onMenuItemClick(item)) {
                 switch (item.getItemId()) {
                     case R.id.favorite:
                         ((FavoriteActionBarView) item.getActionView()).toggle();

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/search/SearchFragment.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/search/SearchFragment.kt
@@ -463,7 +463,7 @@ class SearchFragment :
         override fun onSongOverflowClick(position: Int, v: View, song: Song) {
             val menu = PopupMenu(v.context, v)
             SongMenuUtils.setupSongMenu(menu, false, true, playlistMenuHelper)
-            menu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(parentFragment as MainController,
+            menu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(null,
                     context!!, song, presenter))
             menu.show()
         }

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/songs/list/SongListFragment.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/songs/list/SongListFragment.kt
@@ -301,7 +301,7 @@ class SongListFragment :
     override fun onSongOverflowClick(position: Int, view: View, song: Song) {
         val menu = PopupMenu(context!!, view)
         SongMenuUtils.setupSongMenu(menu, false, true, playlistMenuHelper)
-        menu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(parentFragment as MainController, context!!, song, songsPresenter))
+        menu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(null, context!!, song, songsPresenter))
         menu.show()
     }
 

--- a/app/src/main/java/com/simplecity/amp_library/ui/screens/suggested/SuggestedFragment.kt
+++ b/app/src/main/java/com/simplecity/amp_library/ui/screens/suggested/SuggestedFragment.kt
@@ -198,7 +198,7 @@ class SuggestedFragment :
         override fun onSongOverflowClicked(v: View, position: Int, song: Song) {
             val popupMenu = PopupMenu(context!!, v)
             SongMenuUtils.setupSongMenu(popupMenu, false, true, playlistMenuHelper)
-            popupMenu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(parentFragment as MainController, context!!, song, presenter))
+            popupMenu.setOnMenuItemClickListener(SongMenuUtils.getSongMenuClickListener(null, context!!, song, presenter))
             popupMenu.show()
         }
     }


### PR DESCRIPTION
This PR fixes the crash that occurred when clicking on the overflow button on `SongListFragment` due to a cast error. 