### PR TITLE
chore: bump version code to 5006 and the version name to 1.3.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
         targetSdkVersion Dependencies.targetSdk
 
         versionName Config.versionName
-        versionCode 5005
+        versionCode 5006
 
         resConfigs "en", "zh-rCN", "fr", "de", "ko", "it", "ru", "nl", "tr", "pl", "ro", "hu", "hi-rIN", "uk", "bg-rBG", "en-rGB", "et-rEE", "vi", "pt-rBR", "es", "en-rNZ", "zh-rTW", "es-rES", "ca", "hr", "en-rAU", "eu-rES", "th", "ja"
 

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -1,5 +1,5 @@
 object Config {
 
-    const val versionName = "1.2.0"
+    const val versionName = "1.3.0"
 
 }


### PR DESCRIPTION
This PR is to bump `versionName `and `versionCode `for beta release on Google Play Store.
 `versionName 1.3.0` versionCode `5006`

Enhancements:-
- #17 - Add SCAN_FORWARD event (#109)
- #72 - Track volume data (#112)
- #17 - Collect PLAY_NEXT, ADD_TO_PLAYLIST and ALBUM_SHUFFLE event (#116)
- #102 - Remove song from Playlist (#119)
- #120 - Hide menu options Delete and Blacklist (#124)
- #17 - Add ADD_TO_QUEUE event (#125)
- #17 - Add BIOGRAPHY event (#130)
- #34 - Add Email Us Preference (#132)
- #69 - Add Device information to Firebase (#133)

Bugs:-
- Fix a crash that occurred while clicking on the overflow button (#123)
- #134 - Fix fix artist name bug (#135)